### PR TITLE
fix: Correctly set sideEffects for CSS treeshaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
     "files": [
         "dist"
     ],
-    "sideEffects": false,
+    "sideEffects": [
+        "*.css"
+    ],
     "homepage": "https://yet-another-react-lightbox.com",
     "repository": {
         "type": "git",


### PR DESCRIPTION
By adding "*.css" to the sideEffects, the option tells webpack to not tree shake the imported CSS (e.g. import 'yet-another-react-lightbox/styles.css').

When you set `sideEffects=false`, the CSS imports (which have side effects) will be tree-shaken away, causing problem in projects configured with tree shaking.

See discussion at https://github.com/facebook/docusaurus/issues/7743#issuecomment-1179477733

<!-- Thank you so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed the 'Sending a Pull Request' section of the [contributing guide](https://github.com/igordanchenko/yet-another-react-lightbox/blob/main/CONTRIBUTING.md#sending-a-pull-request)
