### PR TITLE
fix(video): set maxWidth/maxHeight 100% to prevent overflow

### DIFF
--- a/src/plugins/video/VideoSlide.tsx
+++ b/src/plugins/video/VideoSlide.tsx
@@ -60,17 +60,25 @@ export function VideoSlide({ slide, offset }: VideoSlideProps) {
     const { width, height, poster, sources } = slide;
 
     const scaleWidthAndHeight = () => {
-        if (!width || !height || !containerRect) return null;
+        const scalingProps: React.ComponentProps<"video"> = {};
 
-        const widthBound = width / height > containerRect.width / containerRect.height;
-        const elementWidth = widthBound ? containerRect.width : Math.round((containerRect.height / height) * width);
-        const elementHeight = !widthBound ? containerRect.height : Math.round((containerRect.width / width) * height);
+        // to prevent video element overflow from its container
+        scalingProps.style = { maxWidth: "100%", maxHeight: "100%" };
 
-        return {
-            width: elementWidth,
-            height: elementHeight,
-            style: { width: elementWidth, height: elementHeight, maxWidth: "100%", maxHeight: "100%" },
-        };
+        if (width && height && containerRect) {
+            const widthBound = width / height > containerRect.width / containerRect.height;
+            const elementWidth = widthBound ? containerRect.width : Math.round((containerRect.height / height) * width);
+            const elementHeight = !widthBound
+                ? containerRect.height
+                : Math.round((containerRect.width / width) * height);
+
+            scalingProps.width = elementWidth;
+            scalingProps.height = elementHeight;
+            scalingProps.style.width = elementWidth;
+            scalingProps.style.height = elementHeight;
+        }
+
+        return scalingProps;
     };
 
     const resolveBoolean = (attr: keyof Required<Pick<LightboxProps, "video">>["video"]) => {


### PR DESCRIPTION
Unlike images, videos do not shrink to fit the size of the container.

This is inconsistent with the expected behavior of `object-fit: contain`, which is the default user-agent style for `<video/>`.
With this, not only partial of video but controls could also be out of the viewport and make users hard to reach.

You can check the behavior below:
https://codesandbox.io/s/fix-yet-another-react-lightbox-video-size-uw4dre?file=/src/App.tsx

- [x] I have followed the 'Sending a Pull Request' section of the [contributing guide](https://github.com/igordanchenko/yet-another-react-lightbox/blob/main/CONTRIBUTING.md#sending-a-pull-request)