### PR TITLE
Custom separator for Counter plugin

### DIFF
--- a/src/plugins/counter/Counter.tsx
+++ b/src/plugins/counter/Counter.tsx
@@ -10,20 +10,34 @@ import {
     PluginProps,
     useLightboxState,
 } from "../../index.js";
+import { resolveCounterProps } from "./props.js";
 
-export function CounterComponent({ counter: { className, ...rest } = {} }: ComponentProps) {
+export function CounterComponent({ counter }: ComponentProps) {
     const { slides, currentIndex } = useLightboxState();
+
+    const {
+        separator,
+        container: { className, ...rest },
+        // TODO v4: remove legacy configuration options
+        className: legacyClassName,
+        ...legacyRest
+    } = resolveCounterProps(counter);
 
     if (slides.length === 0) return null;
 
     return (
-        <div className={clsx(cssClass("counter"), className)} {...rest}>
-            {currentIndex + 1} / {slides.length}
+        <div className={clsx(cssClass("counter"), className || legacyClassName)} {...legacyRest} {...rest}>
+            {currentIndex + 1} {separator} {slides.length}
         </div>
     );
 }
 
 /** Counter plugin */
-export function Counter({ addChild }: PluginProps) {
+export function Counter({ augment, addChild }: PluginProps) {
+    augment(({ counter, ...restProps }) => ({
+        counter: resolveCounterProps(counter),
+        ...restProps,
+    }));
+
     addChild(MODULE_CONTROLLER, createModule(PLUGIN_COUNTER, CounterComponent));
 }

--- a/src/plugins/counter/index.ts
+++ b/src/plugins/counter/index.ts
@@ -4,8 +4,14 @@ import { Counter } from "./Counter.js";
 
 declare module "../../types.js" {
     interface LightboxProps {
-        /** HTML div element attributes to be passed to the Counter plugin container */
-        counter?: React.HTMLAttributes<HTMLDivElement>;
+        // TODO v4: remove html attributes from `counter` prop
+        /** Counter plugin settings */
+        counter?: React.HTMLAttributes<HTMLDivElement> & {
+            /** custom separator */
+            separator?: string;
+            /** counter container HTML attributes */
+            container?: React.HTMLAttributes<HTMLDivElement>;
+        };
     }
 }
 

--- a/src/plugins/counter/props.ts
+++ b/src/plugins/counter/props.ts
@@ -1,0 +1,11 @@
+import { LightboxProps } from "../../index.js";
+
+export const defaultCounterProps = {
+    separator: "/",
+    container: {},
+} as Required<NonNullable<LightboxProps["counter"]>>;
+
+export const resolveCounterProps = (counter: LightboxProps["counter"]) => ({
+    ...defaultCounterProps,
+    ...counter,
+});


### PR DESCRIPTION
Dear maintainers,

I am pleased to introduce an enhancement to the existing functionality of the Counter plugin in the form of a custom separator feature.

This new functionality allows users to personalize the Counter plugin's separator according to their needs. With this extension, users are no longer limited to the default separator ('/') and can replace it with any string of their choice. This provides a more flexible and customized user experience.

Below is a preview of how this new feature looks:
Custom Separator Feature

To utilize this feature, users can leverage the newly introduced counterSeparator property. This property accepts an argument of string type, representing the desired separator.

Kindly review this proposal for integrating the custom separator feature to the Counter plugin and share your thoughts. Your feedback is greatly appreciated as we strive to continuously improve our library.

Thank you for your time and consideration.