### PR TITLE
Add title attribute to IconButton for enhanced accessibility

### DIFF
--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -6,7 +6,7 @@ import { ELEMENT_BUTTON, ELEMENT_ICON } from "../consts.js";
 
 export type IconButtonProps = Omit<
   React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>,
-  "type" | "aria-label"
+  "type" | "title" | "aria-label"
 > & {
   label: string;
   icon: React.ElementType;
@@ -23,6 +23,7 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(f
     <button
       ref={ref}
       type="button"
+      title={translateLabel(labels, label)}
       aria-label={translateLabel(labels, label)}
       className={clsx(cssClass(ELEMENT_BUTTON), className)}
       onClick={onClick}

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -4,10 +4,7 @@ import { clsx, cssClass, label as translateLabel } from "../utils.js";
 import { useLightboxProps } from "../contexts/index.js";
 import { ELEMENT_BUTTON, ELEMENT_ICON } from "../consts.js";
 
-export type IconButtonProps = Omit<
-  React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>,
-  "type" | "title" | "aria-label"
-> & {
+export type IconButtonProps = React.ComponentProps<"button"> & {
   label: string;
   icon: React.ElementType;
   renderIcon?: () => React.ReactNode;
@@ -18,13 +15,14 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(f
   ref,
 ) {
   const { styles, labels } = useLightboxProps();
+  const buttonLabel = translateLabel(labels, label);
 
   return (
     <button
       ref={ref}
       type="button"
-      title={translateLabel(labels, label)}
-      aria-label={translateLabel(labels, label)}
+      title={buttonLabel}
+      aria-label={buttonLabel}
       className={clsx(cssClass(ELEMENT_BUTTON), className)}
       onClick={onClick}
       style={{ ...style, ...styles.button }}


### PR DESCRIPTION
<!-- Thank you so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed the 'Sending a Pull Request' section of the
      [contributing guide](https://github.com/igordanchenko/yet-another-react-lightbox/blob/main/CONTRIBUTING.md#sending-a-pull-request)

---

By adding a title attribute, we ensure that sighted users receive a tooltip on hover, enhancing the overall usability of the button. This change complements the existing aria-label attribute, making the button more accessible and informative to all users.

- Updated IconButtonProps to omit "title" in addition to "type" and "aria-label".
- Added title={translateLabel(labels, label)} to the button element in the IconButton component.

This change improves the accessibility and usability of our IconButton component by ensuring that all users, including those using screen readers and those who rely on tooltips, can easily understand the button's purpose.
