### PR TITLE
feat: add classNameResolver util function

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -166,6 +166,31 @@ or
   --yarl__color_backdrop: rgba(0, 0, 0, 0.8);
 }
 ```
+#### Custom class names
+
+In case completely custom classnames are needed, e.g. because css classes are 
+prefixed / postfixed during build, a `classNameResolver` can be used:
+
+```jsx
+import { setClassNameResolver } from 'yet-another-react-lightbox';
+import yarlClasses from 'yet-another-react-lightbox/styles.css';
+import yarlCaptionClasses from 'yet-another-react-lightbox/plugins/captions.css';
+
+setClassNameResolver((originalClassName: string) => {
+  const yarlKey = _.camelCase(`yarl_${originalClassName}`);
+
+  if (Object.keys(yarlClasses as Record<string, string>).includes(yarlKey)) {
+    return (yarlClasses as Record<string, string>)[yarlKey];
+  }
+
+  if (Object.keys(yarlCaptionClasses as Record<string, string>).includes(yarlKey)) {
+    return (yarlCaptionClasses as Record<string, string>)[yarlKey];
+  }
+
+  return originalClassName;
+});
+
+```
 
 ## Adding Toolbar Buttons
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,12 @@ import {
   ToolbarSettings,
 } from "./types.js";
 
+let classNameResolver: ((className: string) => string) | undefined;
+
+export function setClassNameResolver(resolver: typeof classNameResolver) {
+  classNameResolver = resolver;
+}
+
 const cssPrefix = "yarl__";
 
 export function clsx(...classes: (string | boolean | undefined)[]) {
@@ -19,7 +25,7 @@ export function clsx(...classes: (string | boolean | undefined)[]) {
 }
 
 export function cssClass(name: string) {
-  return `${cssPrefix}${name}`;
+  return classNameResolver ? classNameResolver(name) : `${cssPrefix}${name}`;
 }
 
 export function cssVar(name: string) {

--- a/test/unit/core/utils.spec.ts
+++ b/test/unit/core/utils.spec.ts
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { render, screen } from "@testing-library/react";
-import { vi } from "vitest";
+import { afterEach, beforeEach, vi } from "vitest";
 
-import { cleanup, clsx, cssClass, cssVar, label, makeUseContext } from "../../../src/utils.js";
+import { cleanup, clsx, cssClass, cssVar, label, makeUseContext, setClassNameResolver } from "../../../src/utils.js";
 import { Labels } from "../../../src/types.js";
 
 describe("utils", () => {
@@ -52,6 +52,20 @@ describe("utils", () => {
   describe("cssClass", () => {
     it("prepends css class prefix", () => {
       expect(cssClass("class")).toBe("yarl__class");
+    });
+
+    describe("with classNameResolver", () => {
+      beforeEach(() => {
+        setClassNameResolver((oName) => `resolved-${oName}-with-postfix`);
+      });
+
+      it("replaces css class with return value", () => {
+        expect(cssClass("class")).toBe("resolved-class-with-postfix");
+      });
+
+      afterEach(() => {
+        setClassNameResolver(undefined);
+      });
     });
   });
 


### PR DESCRIPTION
### Description

This PR add a `setClassNameResolver` util function to allow global modification of how classNames are picked.
In our case we want to use it with hash classname generation and not allowing any global class names.

I first tried to add such configuration to the `Lightbox` props but that turned out as a very big change and so I choose to went to easier but still reliably working way.

### Checklist

- [x] I have followed the 'Sending a Pull Request' section of the [contributing guide](https://github.com/igordanchenko/yet-another-react-lightbox/blob/main/CONTRIBUTING.md#sending-a-pull-request)
