### PR TITLE
fix(thumbnails): prevent rendering more thumbnails than there are slides

### DIFF
--- a/src/plugins/thumbnails/ThumbnailsTrack.tsx
+++ b/src/plugins/thumbnails/ThumbnailsTrack.tsx
@@ -24,7 +24,7 @@ import {
   useRTL,
   useSensors,
 } from "../../index.js";
-import { cssPrefix, cssThumbnailPrefix } from "./utils.js";
+import { calculateThumbnailsRange, cssPrefix, cssThumbnailPrefix } from "./utils.js";
 import { Thumbnail } from "./Thumbnail.js";
 import { defaultThumbnailsProps, useThumbnailsProps } from "./props.js";
 
@@ -110,11 +110,15 @@ export function ThumbnailsTrack({ visible, containerRef }: ThumbnailsTrackProps)
   const items: { key: React.Key; index: number; slide: Slide | null }[] = [];
 
   if (hasSlides(slides)) {
-    for (
-      let index = globalIndex - preload - Math.abs(offset);
-      index <= globalIndex + preload + Math.abs(offset);
-      index += 1
-    ) {
+    const { rangeStart, rangeEnd } = calculateThumbnailsRange(
+      globalIndex,
+      preload,
+      offset,
+      slides.length,
+      carousel.finite,
+    );
+
+    for (let index = rangeStart; index <= rangeEnd; index += 1) {
       const placeholder =
         (carousel.finite && (index < 0 || index > slides.length - 1)) ||
         (offset < 0 && index < globalIndex - preload) ||

--- a/src/plugins/thumbnails/utils.ts
+++ b/src/plugins/thumbnails/utils.ts
@@ -3,3 +3,26 @@ import { composePrefix, PLUGIN_THUMBNAILS } from "../../index.js";
 export const cssPrefix = (value?: string) => composePrefix(PLUGIN_THUMBNAILS, value);
 
 export const cssThumbnailPrefix = (value?: string) => cssPrefix(composePrefix("thumbnail", value));
+
+export function calculateThumbnailsRange(
+  globalIndex: number,
+  preload: number,
+  offset: number,
+  totalSlides: number,
+  finite: boolean,
+) {
+  let rangeStart = globalIndex - preload - Math.abs(offset);
+  let rangeEnd = globalIndex + preload + Math.abs(offset);
+
+  // For infinite carousels, prevent rendering more positions than unique slides
+  if (!finite) {
+    const totalPositions = rangeEnd - rangeStart + 1;
+    if (totalPositions > totalSlides) {
+      const reduction = totalPositions - totalSlides;
+      rangeStart += Math.ceil(reduction / 2);
+      rangeEnd -= Math.floor(reduction / 2);
+    }
+  }
+
+  return { rangeStart, rangeEnd };
+}

--- a/test/unit/plugins/Thumbnails.spec.ts
+++ b/test/unit/plugins/Thumbnails.spec.ts
@@ -139,10 +139,10 @@ describe("Thumbnails", () => {
     for (const [slides, preload, finite, expected] of [
       ...generateTestCases(false, [
         [0, 1, 1, 1],
-        [0, 1, 3, 3, 3],
-        [0, 1, 3, 3, 5, 5, 5],
-        [0, 1, 3, 3, 5, 5, 7, 7, 7],
-        [0, 1, 3, 3, 5, 5, 7, 7, 9, 9, 9],
+        [0, 1, 2, 3, 3],
+        [0, 1, 2, 3, 4, 5, 5],
+        [0, 1, 2, 3, 4, 5, 6, 7, 7],
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9],
       ]),
       ...generateTestCases(true, [
         [0, 1, 1, 1],


### PR DESCRIPTION
### Description
Fixes Issue #384 

When there are only 4 slides, the Thumbnails plugin renders 5 thumbnails. The first and last thumbnail are duplicates. The number of thumbnails should not exceed the number of slides.

<img width="1492" height="894" alt="Screenshot 2025-10-18 at 8 35 22 PM" src="https://github.com/user-attachments/assets/38f5ef90-d658-4359-8791-bee05632d2c4" />

### Checklist

- [x] I have followed the 'Sending a Pull Request' section of the [contributing guide](https://github.com/igordanchenko/yet-another-react-lightbox/blob/main/CONTRIBUTING.md#sending-a-pull-request)
