### PR TITLE
feat: support scrolling and touch swipe behavior for thumbnails

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -80,6 +80,10 @@ via corresponding CSS class.
       <td>thumbnailsContainer</td>
       <td>yarl__thumbnails_container</td>
     </tr>
+    <tr>
+      <td>thumbnailsScrollViewport</td>
+      <td>yarl__thumbnails_scroll_viewport</td>
+    </tr>
   </tbody>
 </table>
 

--- a/docs/plugins/thumbnails.md
+++ b/docs/plugins/thumbnails.md
@@ -5,6 +5,20 @@ slides are supported out of the box. You can specify a thumbnail image for
 custom slide types or override the default thumbnail by adding a `thumbnail`
 slide prop to your slides.
 
+The thumbnail strip scrolls like a normal overflow area. With `position` set to
+`top` or `bottom`, it scrolls horizontally; with `start` or `end`, it scrolls
+vertically. There is one thumbnail per slide, so you can scroll or drag through
+the entire list. The strip stays centered; on wide layouts the visible width or
+height is capped (about `2 * carousel.preload + 1` thumbnail slots) so the bar
+does not stretch across the whole viewport.
+
+When you change slides, the active thumbnail scrolls into view. Clicking a
+thumbnail jumps to that slide. If the carousel loops, navigation uses the
+shorter path around the loop instead of stepping through every slide in between.
+
+To tweak the scrollable region, use `styles.thumbnailsScrollViewport` or the
+`--yarl__thumbnails_scroll_viewport_max` CSS variable.
+
 The plugin comes with an additional CSS stylesheet.
 
 ```jsx

--- a/src/plugins/thumbnails/Thumbnail.tsx
+++ b/src/plugins/thumbnails/Thumbnail.tsx
@@ -78,21 +78,31 @@ export type FadeSettings = {
 export type ThumbnailProps = {
   slide: Slide | null;
   index: number;
-  onClick: () => void;
+  onClick?: () => void;
   fadeIn?: FadeSettings;
   fadeOut?: FadeSettings;
   placeholder: boolean;
   onLoseFocus: () => void;
+  active?: boolean;
 };
 
-export function Thumbnail({ slide, index, onClick, fadeIn, fadeOut, placeholder, onLoseFocus }: ThumbnailProps) {
+export function Thumbnail({
+  slide,
+  index,
+  onClick,
+  fadeIn,
+  fadeOut,
+  placeholder,
+  onLoseFocus,
+  active: activeProp,
+}: ThumbnailProps) {
   const ref = React.useRef<HTMLButtonElement>(null);
   const { render, styles, labels } = useLightboxProps();
   const { slides, globalIndex } = useLightboxState();
   const { getOwnerDocument } = useDocumentContext();
   const { width, height, imageFit } = useThumbnailsProps();
   const rect = { width, height };
-  const active = index === globalIndex;
+  const active = activeProp ?? index === globalIndex;
 
   const onLoseFocusCallback = useEventCallback(onLoseFocus);
 

--- a/src/plugins/thumbnails/ThumbnailsContext.tsx
+++ b/src/plugins/thumbnails/ThumbnailsContext.tsx
@@ -14,7 +14,6 @@ export function ThumbnailsContextProvider({ children, ...props }: ComponentProps
   const { ref, position, hidden } = resolveThumbnailsProps(props.thumbnails);
 
   const [visible, setVisible] = React.useState(!hidden);
-  const containerRef = React.useRef<HTMLDivElement>(null);
 
   const context = React.useMemo(
     () => ({
@@ -30,10 +29,10 @@ export function ThumbnailsContextProvider({ children, ...props }: ComponentProps
   return (
     <LightboxPropsProvider {...props}>
       <ThumbnailsContext.Provider value={context}>
-        <div ref={containerRef} className={clsx(cssClass(cssPrefix()), cssClass(cssPrefix(`${position}`)))}>
-          {["start", "top"].includes(position) && <ThumbnailsTrack containerRef={containerRef} visible={visible} />}
+        <div className={clsx(cssClass(cssPrefix()), cssClass(cssPrefix(`${position}`)))}>
+          {["start", "top"].includes(position) && <ThumbnailsTrack visible={visible} />}
           <div className={cssClass(cssPrefix("wrapper"))}>{children}</div>
-          {["end", "bottom"].includes(position) && <ThumbnailsTrack containerRef={containerRef} visible={visible} />}
+          {["end", "bottom"].includes(position) && <ThumbnailsTrack visible={visible} />}
         </div>
       </ThumbnailsContext.Provider>
     </LightboxPropsProvider>

--- a/src/plugins/thumbnails/ThumbnailsTrack.tsx
+++ b/src/plugins/thumbnails/ThumbnailsTrack.tsx
@@ -3,25 +3,21 @@ import * as React from "react";
 import {
   ACTION_NEXT,
   ACTION_PREV,
-  ACTION_SWIPE,
   calculatePreload,
-  CLASS_FLEX_CENTER,
-  cleanup,
   clsx,
   cssClass,
   cssVar,
-  getSlide,
+  getSlideIndex,
   getSlideKey,
   hasSlides,
   Slide,
   translateLabel,
-  useAnimation,
   useEventCallback,
   useEvents,
   useKeyboardNavigation,
+  useLayoutEffect,
   useLightboxProps,
   useLightboxState,
-  useRTL,
   useSensors,
 } from "../../index.js";
 import { cssPrefix, cssThumbnailPrefix } from "./utils.js";
@@ -30,10 +26,6 @@ import { defaultThumbnailsProps, useThumbnailsProps } from "./props.js";
 
 function isHorizontal(position: ReturnType<typeof useThumbnailsProps>["position"]) {
   return ["top", "bottom"].includes(position);
-}
-
-function boxSize(thumbnails: ReturnType<typeof useThumbnailsProps>, dimension: number) {
-  return dimension + 2 * (thumbnails.border + thumbnails.padding) + thumbnails.gap;
 }
 
 function getThumbnailKey(slide?: Slide | null) {
@@ -50,18 +42,45 @@ function getThumbnailKey(slide?: Slide | null) {
   );
 }
 
+function getShortestCarouselNavigation(
+  globalIndex: number,
+  targetSlideIndex: number,
+  slideCount: number,
+): { type: typeof ACTION_NEXT | typeof ACTION_PREV; count: number } | null {
+  const currentSlideIndex = getSlideIndex(globalIndex, slideCount);
+  if (currentSlideIndex === targetSlideIndex) return null;
+  const stepsForward = (targetSlideIndex - currentSlideIndex + slideCount) % slideCount;
+  const stepsBackward = (currentSlideIndex - targetSlideIndex + slideCount) % slideCount;
+  if (stepsForward <= stepsBackward) {
+    return { type: ACTION_NEXT, count: stepsForward };
+  }
+  return { type: ACTION_PREV, count: stepsBackward };
+}
+
+function scrollThumbnailIntoViewIfNeeded(element: HTMLElement | null | undefined) {
+  const method = element?.scrollIntoView;
+  if (typeof method !== "function") return;
+  try {
+    method.call(element, { block: "nearest", inline: "nearest", behavior: "auto" });
+  } catch {
+    try {
+      method.call(element, false);
+    } catch {
+      method.call(element);
+    }
+  }
+}
+
 export type ThumbnailsTrackProps = {
   visible: boolean;
-  containerRef: React.RefObject<HTMLDivElement | null>;
 };
 
-export function ThumbnailsTrack({ visible, containerRef }: ThumbnailsTrackProps) {
+export function ThumbnailsTrack({ visible }: ThumbnailsTrackProps) {
   const track = React.useRef<HTMLDivElement>(null);
 
-  const isRTL = useRTL();
-  const { publish, subscribe } = useEvents();
+  const { publish } = useEvents();
   const { carousel, styles, labels } = useLightboxProps();
-  const { slides, globalIndex, animation } = useLightboxState();
+  const { slides, globalIndex } = useLightboxState();
   const { registerSensors, subscribeSensors } = useSensors();
 
   useKeyboardNavigation(subscribeSensors);
@@ -70,79 +89,66 @@ export function ThumbnailsTrack({ visible, containerRef }: ThumbnailsTrackProps)
   const { position, width, height, border, borderStyle, borderColor, borderRadius, padding, gap, vignette } =
     thumbnails;
 
-  const offset = (animation?.duration !== undefined && animation?.increment) || 0;
-  const animationDuration = animation?.duration || 0;
-
-  const { prepareAnimation } = useAnimation<number>(track, (snapshot) => ({
-    keyframes: isHorizontal(position)
-      ? [
-          {
-            transform: `translateX(${(isRTL ? -1 : 1) * boxSize(thumbnails, width) * offset + snapshot}px)`,
-          },
-          { transform: "translateX(0)" },
-        ]
-      : [
-          {
-            transform: `translateY(${boxSize(thumbnails, height) * offset + snapshot}px)`,
-          },
-          { transform: "translateY(0)" },
-        ],
-    duration: animationDuration,
-    easing: animation?.easing,
-  }));
-
-  const handleControllerSwipe = useEventCallback(() => {
-    let animationOffset = 0;
-    if (containerRef.current && track.current) {
-      const containerRect = containerRef.current.getBoundingClientRect();
-      const trackRect = track.current.getBoundingClientRect();
-      animationOffset = isHorizontal(position)
-        ? trackRect.left - containerRect.left - (containerRect.width - trackRect.width) / 2
-        : trackRect.top - containerRect.top - (containerRect.height - trackRect.height) / 2;
+  const handleStripWheel = useEventCallback((event: React.WheelEvent) => {
+    const horizontalStrip = isHorizontal(position);
+    if (horizontalStrip) {
+      if (Math.abs(event.deltaX) <= Math.abs(event.deltaY)) return;
+    } else if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) {
+      return;
     }
-
-    prepareAnimation(animationOffset);
+    event.stopPropagation();
   });
 
-  React.useEffect(() => cleanup(subscribe(ACTION_SWIPE, handleControllerSwipe)), [subscribe, handleControllerSwipe]);
+  const stopStripPointerBubble = useEventCallback((event: React.PointerEvent) => {
+    event.stopPropagation();
+  });
 
   const preload = calculatePreload(carousel, slides);
-  const items: { key: React.Key; index: number; slide: Slide | null }[] = [];
 
-  if (hasSlides(slides)) {
-    for (
-      let index = globalIndex - preload - Math.abs(offset);
-      index <= globalIndex + preload + Math.abs(offset);
-      index += 1
-    ) {
-      const placeholder =
-        (carousel.finite && (index < 0 || index > slides.length - 1)) ||
-        (offset < 0 && index < globalIndex - preload) ||
-        (offset > 0 && index > globalIndex + preload);
-      const slide = !placeholder ? getSlide(slides, index) : null;
+  const items = React.useMemo(() => {
+    const list: { key: React.Key; index: number; slide: Slide | null }[] = [];
+    if (!hasSlides(slides)) {
+      return list;
+    }
+    for (let index = 0; index < slides.length; index += 1) {
+      const slide = slides[index];
       const key = [`${index}`, getThumbnailKey(slide)].filter(Boolean).join("|");
-
-      items.push({ key, index, slide });
+      list.push({ key, index, slide });
     }
-  }
+    return list;
+  }, [slides]);
 
-  const handleClick = (slideIndex: number) => () => {
-    if (slideIndex > globalIndex) {
-      publish(ACTION_NEXT, { count: slideIndex - globalIndex });
-    } else if (slideIndex < globalIndex) {
-      publish(ACTION_PREV, { count: globalIndex - slideIndex });
+  const slidesLength = hasSlides(slides) ? slides.length : 0;
+  const activeSlideIndex = slidesLength > 0 ? getSlideIndex(globalIndex, slidesLength) : null;
+
+  const scrollViewportMaxPx = React.useMemo(() => {
+    if (slidesLength === 0) return 0;
+    const visibleSlots = Math.min(slidesLength, 2 * preload + 1);
+    const dim = isHorizontal(position) ? width : height;
+    return visibleSlots * (dim + 2 * (border + padding) + gap) - gap;
+  }, [slidesLength, preload, position, width, height, border, padding, gap]);
+
+  const handleThumbnailClick = useEventCallback((clickedSlideIndex: number) => {
+    if (slidesLength === 0) return;
+    const nav = getShortestCarouselNavigation(globalIndex, clickedSlideIndex, slidesLength);
+    if (nav) {
+      publish(nav.type, { count: nav.count });
     }
-  };
+  });
 
-  return (
-    <div
-      className={clsx(cssClass(cssPrefix("container")), cssClass(CLASS_FLEX_CENTER))}
-      style={{
+  useLayoutEffect(() => {
+    if (!visible || activeSlideIndex === null) {
+      return;
+    }
+    scrollThumbnailIntoViewIfNeeded(track.current?.querySelector<HTMLElement>('[aria-current="true"]'));
+  }, [visible, activeSlideIndex]);
+
+  const containerStyle = React.useMemo(
+    () =>
+      ({
         ...(!visible ? { display: "none" } : null),
-        ...(width !== defaultThumbnailsProps.width ? { [cssVar(cssThumbnailPrefix("width"))]: `${width}px` } : null),
-        ...(height !== defaultThumbnailsProps.height
-          ? { [cssVar(cssThumbnailPrefix("height"))]: `${height}px` }
-          : null),
+        [cssVar(cssThumbnailPrefix("width"))]: `${width}px`,
+        [cssVar(cssThumbnailPrefix("height"))]: `${height}px`,
         ...(border !== defaultThumbnailsProps.border
           ? { [cssVar(cssThumbnailPrefix("border"))]: `${border}px` }
           : null),
@@ -156,56 +162,53 @@ export function ThumbnailsTrack({ visible, containerRef }: ThumbnailsTrackProps)
           : null),
         ...(gap !== defaultThumbnailsProps.gap ? { [cssVar(cssThumbnailPrefix("gap"))]: `${gap}px` } : null),
         ...styles.thumbnailsContainer,
-      }}
+      }) as React.CSSProperties,
+    [visible, width, height, border, borderStyle, borderColor, borderRadius, padding, gap, styles.thumbnailsContainer],
+  );
+
+  const scrollViewportStyle = React.useMemo(() => {
+    const user = styles.thumbnailsScrollViewport;
+    const capVar =
+      scrollViewportMaxPx > 0 ? { [cssVar("thumbnails_scroll_viewport_max")]: `${scrollViewportMaxPx}px` } : undefined;
+    if (!user && !capVar) return undefined;
+    return { ...user, ...capVar } as React.CSSProperties;
+  }, [scrollViewportMaxPx, styles.thumbnailsScrollViewport]);
+
+  return (
+    <div
+      className={clsx(cssClass(cssPrefix("container")), cssClass(cssPrefix("container_scrollable")))}
+      style={containerStyle}
     >
-      <nav
-        ref={track}
-        style={styles.thumbnailsTrack}
-        className={clsx(cssClass(cssPrefix("track")), cssClass(CLASS_FLEX_CENTER))}
-        aria-label={translateLabel(labels, "Thumbnails")}
-        tabIndex={-1}
-        {...registerSensors}
+      <div
+        className={cssClass(cssPrefix("scroll_viewport"))}
+        style={scrollViewportStyle}
+        onWheel={handleStripWheel}
+        onPointerDown={stopStripPointerBubble}
+        onPointerMove={stopStripPointerBubble}
+        onPointerUp={stopStripPointerBubble}
+        onPointerCancel={stopStripPointerBubble}
       >
-        {items.map(({ key, index, slide }) => {
-          const fadeAnimationDuration = animationDuration / Math.abs(offset || 1);
-
-          const fadeIn =
-            (offset > 0 && index > globalIndex + preload - offset && index <= globalIndex + preload) ||
-            (offset < 0 && index < globalIndex - preload - offset && index >= globalIndex - preload)
-              ? {
-                  duration: fadeAnimationDuration,
-                  delay:
-                    ((offset > 0 ? index - (globalIndex + preload - offset) : globalIndex - preload - offset - index) -
-                      1) *
-                    fadeAnimationDuration,
-                }
-              : undefined;
-
-          const fadeOut =
-            (offset > 0 && index < globalIndex - preload) || (offset < 0 && index > globalIndex + preload)
-              ? {
-                  duration: fadeAnimationDuration,
-                  delay:
-                    (offset > 0
-                      ? offset - (globalIndex - preload - index)
-                      : -offset - (index - (globalIndex + preload))) * fadeAnimationDuration,
-                }
-              : undefined;
-
-          return (
+        <nav
+          ref={track}
+          style={styles.thumbnailsTrack}
+          className={cssClass(cssPrefix("track"))}
+          aria-label={translateLabel(labels, "Thumbnails")}
+          tabIndex={-1}
+          {...registerSensors}
+        >
+          {items.map(({ key, index, slide }) => (
             <Thumbnail
               key={key}
               index={index}
               slide={slide}
-              fadeIn={fadeIn}
-              fadeOut={fadeOut}
               placeholder={!slide}
-              onClick={handleClick(index)}
+              onClick={slide ? () => handleThumbnailClick(index) : undefined}
               onLoseFocus={() => track.current?.focus()}
+              active={activeSlideIndex !== null ? activeSlideIndex === index : undefined}
             />
-          );
-        })}
-      </nav>
+          ))}
+        </nav>
+      </div>
       {vignette && <div className={cssClass(cssPrefix("vignette"))} />}
     </div>
   );

--- a/src/plugins/thumbnails/index.ts
+++ b/src/plugins/thumbnails/index.ts
@@ -81,6 +81,8 @@ declare module "../../types.js" {
     thumbnailsTrack: "thumbnailsTrack";
     /** thumbnails container customization slot */
     thumbnailsContainer: "thumbnailsContainer";
+    /** scroll viewport */
+    thumbnailsScrollViewport: "thumbnailsScrollViewport";
   }
 
   // noinspection JSUnusedGlobalSymbols

--- a/src/plugins/thumbnails/thumbnails.scss
+++ b/src/plugins/thumbnails/thumbnails.scss
@@ -38,6 +38,60 @@ $thumbnail-focus-box-shadow:
     -webkit-touch-callout: none;
   }
 
+  &_top &_container_scrollable,
+  &_bottom &_container_scrollable {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+  }
+
+  &_top &_scroll_viewport,
+  &_bottom &_scroll_viewport {
+    overflow-x: auto;
+    overflow-y: hidden;
+    max-width: var(--yarl__thumbnails_scroll_viewport_max, none);
+    width: 100%;
+    min-width: 0;
+    contain: layout;
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-x;
+    overscroll-behavior-x: contain;
+  }
+
+  &_start &_container_scrollable,
+  &_end &_container_scrollable {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    max-height: 100%;
+    min-height: 0;
+    align-self: stretch;
+  }
+
+  &_start &_scroll_viewport,
+  &_end &_scroll_viewport {
+    overflow-y: auto;
+    overflow-x: hidden;
+    max-height: var(--yarl__thumbnails_scroll_viewport_max, none);
+    width: 100%;
+    min-height: 0;
+    contain: layout;
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-y;
+    overscroll-behavior-y: contain;
+  }
+
+  &_scroll_viewport &_track {
+    justify-content: flex-start;
+    touch-action: inherit;
+  }
+
+  &_scroll_viewport &_thumbnail {
+    touch-action: inherit;
+  }
+
   &_vignette {
     position: absolute;
     pointer-events: none;
@@ -83,12 +137,15 @@ $thumbnail-focus-box-shadow:
   }
 
   &_track {
+    display: flex;
     outline: none;
     gap: localVar(thumbnail_gap, 16px);
   }
 
   &_thumbnail {
     flex: 0 0 auto;
+    min-width: localVar(thumbnail_width, 120px);
+    min-height: localVar(thumbnail_height, 80px);
     cursor: pointer;
     appearance: none;
     background: localVar(thumbnail_background, common.$color-black);

--- a/test/types/src/App.tsx
+++ b/test/types/src/App.tsx
@@ -229,6 +229,7 @@ export default function App() {
           thumbnail: { borderColor: "#eee" },
           thumbnailsTrack: { borderColor: "#eee" },
           thumbnailsContainer: { borderColor: "#eee" },
+          thumbnailsScrollViewport: { outline: "none" },
         }}
         labels={{
           Previous: "Custom Previous",

--- a/test/unit/plugins/Thumbnails.spec.ts
+++ b/test/unit/plugins/Thumbnails.spec.ts
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { act, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
 
-import { clickButton, expectCurrentImageToBe, expectToContainButton, lightbox } from "../test-utils.js";
+import { clickButton, expectCurrentImageToBe, expectToContainButton, lightbox, querySelector } from "../test-utils.js";
 import { Fullscreen, Thumbnails, Video } from "../../../src/plugins/index.js";
 import { LightboxExternalProps } from "../../../src/index.js";
 
@@ -128,39 +129,60 @@ describe("Thumbnails", () => {
     clickThumbnail("custom");
   });
 
-  it("renders correct number of thumbnails", () => {
+  it("renders one thumbnail per slide regardless of preload and finite mode", () => {
     const { rerender } = renderLightbox();
 
-    const generateTestCases = (finite: boolean, testCases: number[][]) =>
-      testCases.flatMap((expectedThumbnails, preload) =>
-        expectedThumbnails.map((expected, slides) => [slides, preload, finite, expected] as const),
-      );
+    for (const finite of [false, true]) {
+      for (const preload of [0, 1, 2, 3]) {
+        for (const slidesCount of [0, 1, 2, 3, 5, 7, 9]) {
+          rerender(
+            lightbox({
+              plugins: [Thumbnails],
+              carousel: { preload, finite },
+              slides: Array.from({ length: slidesCount }).map((_, index) => ({ src: `img${index}` })),
+            }),
+          );
 
-    for (const [slides, preload, finite, expected] of [
-      ...generateTestCases(false, [
-        [0, 1, 1, 1],
-        [0, 1, 3, 3, 3],
-        [0, 1, 3, 3, 5, 5, 5],
-        [0, 1, 3, 3, 5, 5, 7, 7, 7],
-        [0, 1, 3, 3, 5, 5, 7, 7, 9, 9, 9],
-      ]),
-      ...generateTestCases(true, [
-        [0, 1, 1, 1],
-        [0, 1, 2, 2, 2],
-        [0, 1, 2, 3, 3, 3],
-        [0, 1, 2, 3, 4, 4, 4],
-        [0, 1, 2, 3, 4, 5, 5, 5],
-      ]),
-    ] as const) {
-      rerender(
-        lightbox({
-          plugins: [Thumbnails],
-          carousel: { preload, finite },
-          slides: Array.from({ length: slides }).map((_, index) => ({ src: `img${index}` })),
-        }),
-      );
-
-      expect(queryThumbnails().length, JSON.stringify({ slides, preload, finite, expected })).toBe(expected);
+          expect(queryThumbnails().length, JSON.stringify({ slidesCount, preload, finite })).toBe(slidesCount);
+        }
+      }
     }
+  });
+
+  it("uses a scroll viewport with max-size CSS variable", () => {
+    renderLightbox();
+    expect(querySelector(".yarl__thumbnails_container_scrollable")).toBeInTheDocument();
+    const viewport = querySelector(".yarl__thumbnails_scroll_viewport");
+    expect(viewport).toBeInTheDocument();
+    expect(viewport?.getAttribute("style")).toContain("--yarl__thumbnails_scroll_viewport_max");
+  });
+
+  it("merges styles.thumbnailsScrollViewport on the scroll viewport", () => {
+    renderLightbox({
+      styles: { thumbnailsScrollViewport: { outline: "2px solid red" } },
+    });
+    const viewport = querySelector(".yarl__thumbnails_scroll_viewport") as HTMLElement;
+    expect(viewport).toBeInTheDocument();
+    expect(viewport.style.outline).toBe("2px solid red");
+    expect(viewport.getAttribute("style")).toContain("--yarl__thumbnails_scroll_viewport_max");
+  });
+
+  it("calls scrollIntoView when the active thumbnail index changes", () => {
+    const scrollIntoView = vi.spyOn(HTMLElement.prototype, "scrollIntoView");
+    renderLightbox();
+    scrollIntoView.mockClear();
+    clickButton("Next");
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest", inline: "nearest", behavior: "auto" });
+    scrollIntoView.mockRestore();
+  });
+
+  it("supports thumbnails navigation with preload 0", () => {
+    renderLightbox({ carousel: { preload: 0 } });
+    expectCurrentImageToBe("image1");
+    clickThumbnail("image2");
+    expectCurrentImageToBe("image2");
+    clickThumbnail("image1");
+    expectCurrentImageToBe("image1");
   });
 });

--- a/test/unit/setup.ts
+++ b/test/unit/setup.ts
@@ -1,4 +1,11 @@
 import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+
+Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+  configurable: true,
+  writable: true,
+  value: vi.fn(),
+});
 
 Object.defineProperties(window.HTMLElement.prototype, {
   clientWidth: {


### PR DESCRIPTION
### Description
This PR supports scrolling and touch swipe behavior for thumbnails.

Mobile (touch swipe to navigate thumbnails)
https://github.com/user-attachments/assets/ee99a1c6-f25a-45af-a1cf-d17d520be3e4

Desktop (horizontal scrolling on thumbnails in example)
https://github.com/user-attachments/assets/7d37970f-90cd-4c64-a0f2-641b54b0228d

- You can scroll or swipe along the thumbnail bar to reach any slide.
- The bar stays visually compact on wide screens (it doesn’t stretch edge to edge), but you can still scroll to thumbnails that are off screen.
- Clicking a thumbnail still jumps to that slide; on a looping carousel, it picks the shorter direction around the loop.
- When you change slides (e.g. with arrows), the active thumbnail scrolls into view so you can always see which one is selected.

### Checklist

- [X] I have followed the 'Sending a Pull Request' section of the [contributing guide](https://github.com/igordanchenko/yet-another-react-lightbox/blob/main/CONTRIBUTING.md#sending-a-pull-request)
