### PR TITLE
fix(download): use server-provided filename for cross-origin downloads

### DIFF
--- a/src/plugins/download/FileSaver.ts
+++ b/src/plugins/download/FileSaver.ts
@@ -3,12 +3,40 @@
  * https://github.com/eligrey/FileSaver.js/blob/master/src/FileSaver.js
  */
 
+export function parseContentDispositionFilename(disposition: string | null) {
+  if (!disposition) {
+    return undefined;
+  }
+
+  // RFC 5987 `filename*` takes precedence over `filename` (RFC 6266)
+  const extended = /filename\*\s*=\s*UTF-8''([^;]+)/i.exec(disposition);
+  if (extended) {
+    try {
+      const decoded = decodeURIComponent(extended[1].trim());
+      if (decoded) {
+        return decoded;
+      }
+    } catch (_) {
+      //
+    }
+  }
+
+  const plain = /filename\s*=\s*("[^"]*"|[^;]+)/i.exec(disposition);
+  return plain?.[1].trim().replace(/^"(.*)"$/, "$1") || undefined;
+}
+
+function getContentDisposition(xhr: XMLHttpRequest) {
+  // unlike `getResponseHeader()`, `getAllResponseHeaders()` doesn't produce console errors
+  // when the header is not exposed through `Access-Control-Expose-Headers`
+  return /^content-disposition:(.*)$/im.exec(xhr.getAllResponseHeaders())?.[1] ?? null;
+}
+
 function download(url: string, name?: string) {
   const xhr = new XMLHttpRequest();
   xhr.open("GET", url);
   xhr.responseType = "blob";
   xhr.onload = () => {
-    saveAs(xhr.response, name);
+    saveAs(xhr.response, name || parseContentDispositionFilename(getContentDisposition(xhr)));
   };
   xhr.onerror = () => {
     // eslint-disable-next-line no-console

--- a/test/unit/plugins/Download.spec.ts
+++ b/test/unit/plugins/Download.spec.ts
@@ -4,6 +4,7 @@ import { vi } from "vitest";
 import { clickButton, lightbox, expectLightboxToBeOpen } from "../test-utils.js";
 import { Download } from "../../../src/plugins/index.js";
 import { LightboxExternalProps } from "../../../src/index.js";
+import { parseContentDispositionFilename } from "../../../src/plugins/download/FileSaver.js";
 
 function renderLightbox(props?: LightboxExternalProps) {
   return render(lightbox({ plugins: [Download], ...props }));
@@ -44,5 +45,32 @@ describe("Download", () => {
     clickButton("Download");
 
     expect(download).toHaveBeenCalled();
+  });
+
+  it("parses Content-Disposition filename", () => {
+    expect(parseContentDispositionFilename(null)).toBeUndefined();
+    expect(parseContentDispositionFilename("")).toBeUndefined();
+    expect(parseContentDispositionFilename("inline")).toBeUndefined();
+    expect(parseContentDispositionFilename('inline; filename=""')).toBeUndefined();
+
+    expect(parseContentDispositionFilename('inline; filename="photo.jpg"')).toBe("photo.jpg");
+    expect(parseContentDispositionFilename("attachment; filename=photo.jpg")).toBe("photo.jpg");
+    expect(parseContentDispositionFilename("attachment; filename = photo.jpg ; size=1024")).toBe("photo.jpg");
+
+    // RFC 5987 encoded filename takes precedence
+    expect(parseContentDispositionFilename("attachment; filename*=UTF-8''na%C3%AFve.jpg")).toBe("naïve.jpg");
+    expect(
+      parseContentDispositionFilename("attachment; filename=\"fallback.jpg\"; filename*=UTF-8''f%C3%B8t%C3%B8.jpg"),
+    ).toBe("føtø.jpg");
+
+    // malformed percent-encoding falls back to the plain filename
+    expect(parseContentDispositionFilename("attachment; filename*=UTF-8''%E0%A4%A; filename=\"fallback.jpg\"")).toBe(
+      "fallback.jpg",
+    );
+
+    // empty encoded filename falls back to the plain filename
+    expect(parseContentDispositionFilename("attachment; filename*=UTF-8'' ; filename=\"fallback.jpg\"")).toBe(
+      "fallback.jpg",
+    );
   });
 });


### PR DESCRIPTION
### Description

Use the server-provided `Content-Disposition` filename when downloading cross-origin files over CORS.

**Problem.** When the Download plugin handles a cross-origin file with CORS enabled, it fetches the file via XHR and saves it through a blob URL. In that path, the original response headers were discarded, so the browser saved the file under a generated blob name (a UUID) unless `download.filename` was explicitly configured — even when the server correctly announced a filename:

```
Access-Control-Expose-Headers: Content-Disposition
Content-Disposition: inline; filename="manual_photo.jpg"
```

**Fix.** The filename from the `Content-Disposition` response header is now used as a fallback when no explicit filename is provided:

- Filename resolution priority: explicit slide `download.filename` / `downloadFilename` → header filename → blob fallback (unchanged previous behavior).
- Both the plain `filename="..."` form and the RFC 5987 `filename*=UTF-8''...` form are supported, with `filename*` taking precedence per RFC 6266 and graceful fallback to the plain form when percent-decoding fails.
- The header is read by parsing `getAllResponseHeaders()` rather than calling `getResponseHeader("Content-Disposition")` — the latter triggers a "Refused to get unsafe header" console error in Chromium when the header is not exposed through `Access-Control-Expose-Headers`.

**Notes.** This only takes effect when the server exposes the header via `Access-Control-Expose-Headers: Content-Disposition`; otherwise the header is invisible to JavaScript on cross-origin responses (a browser constraint), and behavior is unchanged. Same-origin downloads are unaffected — the browser already applies the header filename in that path.

**Testing.** Unit tests cover the parser (quoted/unquoted filenames, whitespace and extra parameters, RFC 5987 precedence, malformed and empty encoded filenames, missing header). The end-to-end behavior was verified in Chromium against a local cross-origin test server covering five scenarios: exposed header, RFC 5987 filename, header present but not exposed, no header, and explicit filename override.

### Checklist

- [x] I have followed the 'Sending a Pull Request' section of the [contributing guide](https://github.com/igordanchenko/yet-another-react-lightbox/blob/main/CONTRIBUTING.md#sending-a-pull-request)

Fix #416
